### PR TITLE
Fix CMD for slc6-dirac

### DIFF
--- a/slc6-dirac/Dockerfile
+++ b/slc6-dirac/Dockerfile
@@ -10,4 +10,4 @@ RUN yum install -y git openssl freetype fontconfig pixman libXrender htop psmisc
     yum clean all && \
     rm -rf /var/lib/apt/lists/* /lib/modules/* /lib/firmware/* /lib/kbd /var/cache/yum
 
-CMD ["/usr/sbin/init"]
+CMD ["/sbin/init"]


### PR DESCRIPTION
Fixes this crash with the integration tests:
```
Creating mysql ... 
Creating elasticsearch ... 

Creating mysql         ... done

Creating elasticsearch ... done
Creating server        ... 

Creating server        ... error

ERROR: for server  Cannot start service dirac-server: OCI runtime create failed: container_linux.go:346: starting container process caused "exec: \"/usr/sbin/init\": stat /usr/sbin/init: no such file or directory": unknown

ERROR: for dirac-server  Cannot start service dirac-server: OCI runtime create failed: container_linux.go:346: starting container process caused "exec: \"/usr/sbin/init\": stat /usr/sbin/init: no such file or directory": unknown
Encountered errors while bringing up the project.
```

I've tested building it [here](https://github.com/chrisburr/management/runs/390576941) (failure is when trying to push) and ran the CI tests with the resulting image [here](https://gitlab.cern.ch/CLICdp/iLCDirac/diracos-test/-/jobs/6776825).