### PR TITLE
Remove runit from init scripts for SLC6

### DIFF
--- a/slc6-dirac/Dockerfile
+++ b/slc6-dirac/Dockerfile
@@ -7,6 +7,7 @@ ARG RUNIT_RPM=runit-2.1.2-1.el6.x86_64.rpm
 
 RUN yum install -y git openssl freetype fontconfig pixman libXrender htop psmisc && \
     yum localinstall -y "http://diracproject.web.cern.ch/diracproject/rpm/${RUNIT_RPM}" && \
+    rm /etc/init/runsvdir.conf && \
     yum clean all && \
     rm -rf /var/lib/apt/lists/* /lib/modules/* /lib/firmware/* /lib/kbd /var/cache/yum
 


### PR DESCRIPTION
Remove `/etc/init/runsvdir.conf` as it should be created and configured when installing DIRAC.