### PR TITLE
docker-compose-dirac: Use Python 3 and alpine no longer supports Python 2

### DIFF
--- a/docker-compose-dirac/Dockerfile
+++ b/docker-compose-dirac/Dockerfile
@@ -5,7 +5,7 @@
 #.......................................................................
 FROM docker:latest
 
-RUN apk add --update py-pip python-dev libffi-dev openssl-dev gcc libc-dev make curl bash git && \
+RUN apk add --update py3-pip python3-dev libffi-dev openssl-dev gcc libc-dev make curl bash git && \
     pip install docker-compose && \
     rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
Fixes the "Create images" job which has been failing for a while.