### PR TITLE
Add conda-recipes for DIRACOS2

### DIFF
--- a/conda-recipes/README.md
+++ b/conda-recipes/README.md
@@ -4,13 +4,13 @@ This directory contains the recipes that are used to generate the packages on th
 This should only be used in situations where it is impractical to add packages to [conda-forge](https://conda-forge.org/) directly.
 New packages can be added to conda-forge using [`staged-recipes`](https://github.com/conda-forge/staged-recipes/) and existing packages can be modified by making a PR to the corresponding [`feedstock`](https://conda-forge.org/feedstocks/).
 
-If it is absolutely essential for DIRAC to have a custom build of a package, a new directory can be added here. An reference for the `meta.yaml` syntax can be found [here](https://conda.io/projects/conda-build/en/latest/resources/define-metadata.html) and the [conda-forge](https://conda-forge.org/feedstocks/) is a good source of examples. You can then test building packages by running:
+If it is absolutely essential for DIRAC to have a custom build of a package, a new directory can be added here. A reference for the `meta.yaml` syntax can be found [here](https://conda.io/projects/conda-build/en/latest/resources/define-metadata.html) and the [conda-forge](https://conda-forge.org/feedstocks/) is a good source of examples. You can then test building packages by running:
 
 ```bash
 conda build -c diracgrid -c conda-forge -m conda_build_config.yaml my-package/
 ```
 
-The `extra-packages/conda_build_config.yaml` file is a "[variant config file](https://conda.io/projects/conda-build/en/latest/resources/variants.html#creating-conda-build-variant-config-files)" which is used to constrain the versions of dependencies. Currently this is only used to set the Python interpreter version. If shared library dependencies are added, new values should be added based on the main [conda-forge configuration](https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/master/recipe/conda_build_config.yaml).
+The `conda-recipes/conda_build_config.yaml` file is a "[variant config file](https://conda.io/projects/conda-build/en/latest/resources/variants.html#creating-conda-build-variant-config-files)" which is used to constrain the versions of dependencies. Currently this is only used to set the Python interpreter version. If shared library dependencies are added, new values should be added based on the main [conda-forge configuration](https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/master/recipe/conda_build_config.yaml).
 
 ## Packages
 

--- a/conda-recipes/README.md
+++ b/conda-recipes/README.md
@@ -19,11 +19,11 @@ The `extra-packages/conda_build_config.yaml` file is a "[variant config file](ht
 **Reason for not using conda-forge:** This package is distributed using DIRACGrid's channel as it is a fork of the main upstream package, making it ineligible for conda-forge.
 
 **Version history:**
-* `5.1.1+dirac.1` Initial release
+* `5.1.1+dirac.1-0` Initial release
 
 ### tornado_m2crypto
 
 **Reason for not using conda-forge:** This package is completely non-functional without DIRACGrid's fork of tornado.
 
 **Version history:**
-* `1.0.0-0` Initial release
+* `0.1.1-0` Initial release

--- a/conda-recipes/README.md
+++ b/conda-recipes/README.md
@@ -1,0 +1,29 @@
+# DIRACGrid's Conda recipes
+
+This directory contains the recipes that are used to generate the packages on the [`diracgrid`](https://anaconda.org/diracgrid/) conda channel.
+This should only be used in situations where it is impractical to add packages to [conda-forge](https://conda-forge.org/) directly.
+New packages can be added to conda-forge using [`staged-recipes`](https://github.com/conda-forge/staged-recipes/) and existing packages can be modified by making a PR to the corresponding [`feedstock`](https://conda-forge.org/feedstocks/).
+
+If it is absolutely essential for DIRAC to have a custom build of a package, a new directory can be added here. An reference for the `meta.yaml` syntax can be found [here](https://conda.io/projects/conda-build/en/latest/resources/define-metadata.html) and the [conda-forge](https://conda-forge.org/feedstocks/) is a good source of examples. You can then test building packages by running:
+
+```bash
+conda build -c diracgrid -c conda-forge -m conda_build_config.yaml my-package/
+```
+
+The `extra-packages/conda_build_config.yaml` file is a "[variant config file](https://conda.io/projects/conda-build/en/latest/resources/variants.html#creating-conda-build-variant-config-files)" which is used to constrain the versions of dependencies. Currently this is only used to set the Python interpreter version. If shared library dependencies are added, new values should be added based on the main [conda-forge configuration](https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/master/recipe/conda_build_config.yaml).
+
+## Packages
+
+### tornado
+
+**Reason for not using conda-forge:** This package is distributed using DIRACGrid's channel as it is a fork of the main upstream package, making it ineligible for conda-forge.
+
+**Version history:**
+* `5.1.1+dirac.1` Initial release
+
+### tornado_m2crypto
+
+**Reason for not using conda-forge:** This package is completely non-functional without DIRACGrid's fork of tornado.
+
+**Version history:**
+* `1.0.0-0` Initial release

--- a/conda-recipes/README.md
+++ b/conda-recipes/README.md
@@ -12,6 +12,19 @@ conda build -c diracgrid -c conda-forge -m conda_build_config.yaml my-package/
 
 The `conda-recipes/conda_build_config.yaml` file is a "[variant config file](https://conda.io/projects/conda-build/en/latest/resources/variants.html#creating-conda-build-variant-config-files)" which is used to constrain the versions of dependencies. Currently this is only used to set the Python interpreter version. If shared library dependencies are added, new values should be added based on the main [conda-forge configuration](https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/master/recipe/conda_build_config.yaml).
 
+Once a newly built package is ready, it can be uploaded to the [`diracgrid`](https://anaconda.org/diracgrid/) conda channel using:
+
+```bash
+# Install the anaconda CLI client
+conda install anaconda-client
+# Login using your anaconda.org credentials
+anaconda login
+# Upload the binary, the file path will be printed at the end of the conda-build log
+anaconda upload path/to/my/package.tar.bz2 --user diracgrid
+```
+
+As this is forseen as to be a rare operation, contious integration is not currently being used for building and uploading packages.
+
 ## Packages
 
 ### tornado

--- a/conda-recipes/conda_build_config.yaml
+++ b/conda-recipes/conda_build_config.yaml
@@ -1,0 +1,4 @@
+# In general the entries in this file should be similar to conda-forge's config
+# https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/master/recipe/conda_build_config.yaml
+python:
+  - 3.8.* *_cpython

--- a/conda-recipes/tornado/meta.yaml
+++ b/conda-recipes/tornado/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "tornado" %}
+# As we have forked tornado, use a local version identifier
+# https://www.python.org/dev/peps/pep-0440/#local-version-segments
+{% set version = "5.1.1+dirac.1" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/DIRACGrid/tornado/archive/v{{ version }}.tar.gz
+  sha256: todo
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+  host:
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - tornado
+    - tornado.platform
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: http://www.tornadoweb.org/
+  summary: Fork of tornado for DIRAC with a patch to allow for configurable iostream
+  license: Apache-2.0
+  license_file: LICENSE

--- a/conda-recipes/tornado/meta.yaml
+++ b/conda-recipes/tornado/meta.yaml
@@ -10,7 +10,7 @@ package:
 
 source:
   url: https://github.com/DIRACGrid/tornado/archive/v{{ version }}.tar.gz
-  sha256: todo
+  sha256: f3ec835380323e9d38ca930bb088bb827eaa544f7a34702c9c9815ae4aafd362
 
 build:
   number: 0

--- a/conda-recipes/tornado_m2crypto/meta.yaml
+++ b/conda-recipes/tornado_m2crypto/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tornado_m2crypto" %}
-{% set version = "0.1.0" %}
+{% set version = "0.1.1" %}
 
 
 package:
@@ -7,8 +7,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/DIRACGrid/tornado_m2crypto/archive/v{{ version }}.tar.gz
-  sha256: 58d9ead79170a8f0e12679c25cf7f4263681e37a8b79ce492ee17141d92357d4
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/tornado_m2crypto-{{ version }}.tar.gz
+  sha256: 89c43805bb540024cd5365188f8db039a2f5cc581dd8f148a31495d744ff724a
 
 build:
   noarch: python
@@ -18,12 +18,12 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.4
+    - python
     - setuptools_scm
   run:
-    # Mark as requiring Python 3 to avoid the enum34 requirement
-    - python >=3.4
+    - enum34
     - m2crypto
+    - python
     - tornado ==5.1.1+dirac.*
 
 test:
@@ -32,13 +32,15 @@ test:
     - tornado_m2crypto.m2httputil
     - tornado_m2crypto.m2iostream
     - tornado_m2crypto.m2netutil
+    - tornado_m2crypto.test
   commands:
     - pip check
   requires:
     - pip
 
 about:
-  home: https://github.com/chaen/tornado_m2crypto
-  summary: Extension to run tornado with M2Crypto instead of the standard python SSL module
+  home: https://github.com/DIRACGrid/tornado_m2crypto
+  summary: Extension for running tornado with M2Crypto instead of the standard python SSL module
+  dev_url: https://github.com/DIRACGrid/tornado_m2crypto/
   license: GPL-3.0-or-later
   license_file: LICENSE

--- a/conda-recipes/tornado_m2crypto/meta.yaml
+++ b/conda-recipes/tornado_m2crypto/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tornado_m2crypto" %}
-{% set version = "0.0.1" %}
+{% set version = "0.1.0" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/DIRACGrid/tornado_m2crypto/archive/v{{ version }}.tar.gz
-  sha256: todo
+  sha256: 58d9ead79170a8f0e12679c25cf7f4263681e37a8b79ce492ee17141d92357d4
 
 build:
   noarch: python

--- a/conda-recipes/tornado_m2crypto/meta.yaml
+++ b/conda-recipes/tornado_m2crypto/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "tornado_m2crypto" %}
+{% set version = "0.0.1" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/DIRACGrid/tornado_m2crypto/archive/v{{ version }}.tar.gz
+  sha256: todo
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python >=3.4
+    - setuptools_scm
+  run:
+    # Mark as requiring Python 3 to avoid the enum34 requirement
+    - python >=3.4
+    - m2crypto
+    - tornado ==5.1.1+dirac.*
+
+test:
+  imports:
+    - tornado_m2crypto
+    - tornado_m2crypto.m2httputil
+    - tornado_m2crypto.m2iostream
+    - tornado_m2crypto.m2netutil
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/chaen/tornado_m2crypto
+  summary: Extension to run tornado with M2Crypto instead of the standard python SSL module
+  license: GPL-3.0-or-later
+  license_file: LICENSE


### PR DESCRIPTION
This PR adds recipes for conda-packages which we can't include in conda-forge. I've already built these and uploaded them to the [diracgrid](https://anaconda.org/diracgrid/) channels on anaconda.org where we have ~5GB of storage for free. See the README for more details.

Requires (already merged now):
* https://github.com/DIRACGrid/tornado_m2crypto/pull/1
* https://github.com/DIRACGrid/tornado_m2crypto/pull/2
* https://github.com/DIRACGrid/tornado/pull/1