### PR TITLE
Create docker image for building DIRACOS

### DIFF
--- a/.github/workflows/images-creator.yml
+++ b/.github/workflows/images-creator.yml
@@ -172,3 +172,32 @@ jobs:
           else
             echo "Skipping deploy no secrets present";
           fi
+
+  # Image for building DIRAOS
+  dirac-cvmfs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: build
+        run: |
+          echo $PWD
+          ls -l
+          docker build -t centos6 centos6/
+      - name: tag
+        run: |
+          docker tag dirac-cvmfs diracgrid/centos6:latest
+          docker tag dirac-cvmfs ghcr.io/diracgrid/management/centos6:latest
+      - name: show
+        run: docker images
+      - name: login and push
+        env:
+          deploy_secret: ${{ secrets.DOCKER_HUB_USERNAME }}
+        run: |
+          if [ ! -z ${deploy_secret} ]; then
+            echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login --username ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin;
+            echo ${{ secrets.CR_PAT }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin;
+            docker push diracgrid/centos6:latest;
+            docker push ghcr.io/diracgrid/management/centos6:latest;
+          else
+            echo "Skipping deploy no secrets present";
+          fi

--- a/centos6/CentOS-Vault.repo
+++ b/centos6/CentOS-Vault.repo
@@ -1,0 +1,41 @@
+# CentOS-Vault.repo
+#
+# CentOS Vault holds packages from previous releases within the same CentOS Version
+# these are packages obsoleted by the current release and should usually not 
+# be used in production
+#-----------------
+
+[C6.10-base]
+name=CentOS-6.10 - Base
+baseurl=http://vault.centos.org/6.10/os/$basearch/
+gpgcheck=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=1
+
+[C6.10-updates]
+name=CentOS-6.10 - Updates
+baseurl=http://vault.centos.org/6.10/updates/$basearch/
+gpgcheck=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=1
+
+[C6.10-extras]
+name=CentOS-6.10 - Extras
+baseurl=http://vault.centos.org/6.10/extras/$basearch/
+gpgcheck=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=1
+
+[C6.10-contrib]
+name=CentOS-6.10 - Contrib
+baseurl=http://vault.centos.org/6.10/contrib/$basearch/
+gpgcheck=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=1
+
+[C6.10-centosplus]
+name=CentOS-6.10 - CentOSPlus
+baseurl=http://vault.centos.org/6.10/centosplus/$basearch/
+gpgcheck=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=1

--- a/centos6/Dockerfile
+++ b/centos6/Dockerfile
@@ -1,0 +1,18 @@
+FROM centos:6
+LABEL maintainer="marko.petric@cern.ch"
+ENV container docker
+
+# Remove obsolete repos
+RUN rm -rf /etc/yum.repos.d/*
+
+# Install enabled Vault Repo
+COPY CentOS-Vault.repo /etc/yum.repos.d/CentOS-Vault.repo
+
+# Install EPEL 
+RUN yum install -y epel-release
+
+# Install DIRACOS requirements
+RUN yum install -y mock rpm-build fedora-packager createrepo python-pip
+
+# Run bash as user default command
+CMD ["/bin/bash"]


### PR DESCRIPTION
Since all normal mirror for CentOS 6 have been disabled or will be disabled soon, the only semi reliable option remains to use CentOS-Vault. This images setups yum to use this repo. And as this will most likely become the prerequisite to build DIRACOS I am adding to management.