### PR TITLE
Add trusted CA and voms clients as needed for running gsissh

### DIFF
--- a/dirac-cvmfs/Dockerfile
+++ b/dirac-cvmfs/Dockerfile
@@ -4,4 +4,8 @@
 #..................................................................
 FROM cern/cc7-base:latest
 
-RUN yum install -y globus-ftp-client gsissh gsi-openssh-clients
+# Add the EGI trustanchors and CAs
+ADD http://repository.egi.eu/sw/production/cas/1/current/repo-files/EGI-trustanchors.repo /etc/yum.repos.d/EGI-trustanchors.repo
+RUN yum install -y ca-policy-egi-core
+
+RUN yum install -y globus-ftp-client gsissh gsi-openssh-clients voms-clients


### PR DESCRIPTION
Update `dirac-cvmfs` image as there need to trusted CA and voms client to use gsissh