### PR TITLE
Add py3-cryptography as needed for resolving dependencies of docker-compose

### DIFF
--- a/docker-compose-dirac/Dockerfile
+++ b/docker-compose-dirac/Dockerfile
@@ -5,7 +5,7 @@
 #.......................................................................
 FROM docker:latest
 
-RUN apk add --update py3-pip python3-dev libffi-dev openssl-dev gcc libc-dev make curl bash git && \
+RUN apk add --update py3-pip python3-dev libffi-dev openssl-dev gcc libc-dev make curl bash git py3-cryptography && \
     pip install docker-compose && \
     rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
This resolves the build failures observed in #30 that are not related to that PR