### PR TITLE
Add recipe for fts3 package

### DIFF
--- a/conda-recipes/fts3/meta.yaml
+++ b/conda-recipes/fts3/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "fts3" %}
-{% set version = "0.0.0.1.dev1" %}
+{% set version = "0.0.0.1.dev2" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   git_url: https://gitlab.cern.ch/chaen/fts-rest-flask.git
-  git_rev: 21e89541559ca497daebff6e51fd883ffcb458a1
+  git_rev: b77ebdc9995083d05113cdf18151d2debb2025ca
 
 build:
   noarch: python

--- a/conda-recipes/fts3/meta.yaml
+++ b/conda-recipes/fts3/meta.yaml
@@ -1,0 +1,56 @@
+{% set name = "fts3" %}
+{% set version = "0.0.0.1.dev1" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  git_url: https://gitlab.cern.ch/chaen/fts-rest-flask.git
+  git_rev: 21e89541559ca497daebff6e51fd883ffcb458a1
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv
+  entry_points:
+    - fts-rest-ban = fts3.scripts.fts_rest_ban:main
+    - fts-rest-delegate = fts3.scripts.fts_rest_delegate:main
+    - fts-rest-delete-submit = fts3.scripts.fts_rest_delete_submit:main
+    - fts-rest-server-status = fts3.scripts.fts_rest_server_status:main
+    - fts-rest-transfer-cancel = fts3.scripts.fts_rest_transfer_cancel:main
+    - fts-rest-transfer-list = fts3.scripts.fts_rest_transfer_list:main
+    - fts-rest-transfer-status = fts3.scripts.fts_rest_transfer_status:main
+    - fts-rest-transfer-submit = fts3.scripts.fts_rest_transfer_submit:main
+    - fts-rest-whoami = fts3.scripts.fts_rest_whoami:main
+
+requirements:
+  host:
+    - pip
+    - python >=3.6
+    - setuptools_scm
+  run:
+    - python >=3.6
+    - m2crypto
+    - requests
+    - setuptools
+
+
+test:
+  imports:
+    - fts3
+    - fts3.cli
+    - fts3.rest
+    - fts3.scripts
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://gitlab.cern.ch/fts/fts-rest-flask
+  summary: FTS Python 3 CLI and libraries
+  dev_url: https://gitlab.cern.ch/fts/fts-rest-flask
+  license: Apache-2.0
+  license_file: LICENSE


### PR DESCRIPTION
As https://gitlab.cern.ch/fts/fts-rest-flask/-/merge_requests/80 has been waiting for over 6 months and it's now blocking the release of DIRAC 7.3 I'm adding a package to build from @chaen's branch for inclusion in DIRACOS2. The binary has already been uploaded to here: https://anaconda.org/diracgrid/fts3

Once it gets officially tagged we can add it to conda-forge and remove it from the main label.