### PR TITLE
change: X509_VOMSES, X509_VOMS_DIR use Dirac provided files if variables point to bad location

### DIFF
--- a/dirac-install.py
+++ b/dirac-install.py
@@ -2121,19 +2121,13 @@ def createBashrc():
 
       # Add sanity check for X509_VOMS_DIR variable
       lines.extend(['if ! checkDir "$X509_VOMS_DIR" ; then',
-                    '  export X509_VOMS_DIR="/etc/grid-security/vomsdir"',
-                    '  if ! checkDir "$X509_VOMS_DIR" ; then',
-                    '    export X509_VOMS_DIR="%s/etc/grid-security/vomsdir"' % proPath,
-                    '  fi',
+                    '  export X509_VOMS_DIR="%s/etc/grid-security/vomsdir"' % proPath,
                     'fi',
                     ''])
 
       # Add sanity check for X509_VOMSES variable
       lines.extend(['if ! checkDir "$X509_VOMSES" ; then',
-                    '  export X509_VOMSES="/etc/vomses"',
-                    '  if ! checkDir "$X509_VOMSES" ; then',
-                    '    export X509_VOMSES="%s/etc/grid-security/vomses"' % proPath,
-                    '  fi',
+                    '  export X509_VOMSES="%s/etc/grid-security/vomses"' % proPath,
                     'fi',
                     ''])
 


### PR DESCRIPTION
Edit: changed behavior to not fall back to `/etc` files

Addressing https://github.com/DIRACGrid/DIRAC/discussions/5441