### PR TITLE
fix (X509_VOMS*): X509_VOMSES, X509_VOMS_DIR use Dirac provided files…

### DIFF
--- a/dirac-install.py
+++ b/dirac-install.py
@@ -2482,19 +2482,13 @@ def createBashrcForDiracOS():
 
       # Add sanity check for X509_VOMS_DIR variable
       lines.extend(['if ! checkDir "$X509_VOMS_DIR" ; then',
-                    '  export X509_VOMS_DIR="/etc/grid-security/vomsdir"',
-                    '  if ! checkDir "$X509_VOMS_DIR" ; then',
-                    '    export X509_VOMS_DIR="%s/etc/grid-security/vomsdir"' % proPath,
-                    '  fi',
+                    '  export X509_VOMS_DIR="%s/etc/grid-security/vomsdir"' % proPath,
                     'fi',
                     ''])
 
       # Add sanity check for X509_VOMSES variable
       lines.extend(['if ! checkDir "$X509_VOMSES" ; then',
-                    '  export X509_VOMSES="/etc/vomses"',
-                    '  if ! checkDir "$X509_VOMSES" ; then',
-                    '    export X509_VOMSES="%s/etc/grid-security/vomses"' % proPath,
-                    '  fi',
+                    '  export X509_VOMSES="%s/etc/grid-security/vomses"' % proPath,
                     'fi',
                     ''])
 


### PR DESCRIPTION
… if variables point to bad location

Also change this in bashrc for diracos, which was missed in #50 