### PR TITLE
Remove enum34 from tornado_m2crypto dependencies

### DIFF
--- a/conda-recipes/tornado_m2crypto/meta.yaml
+++ b/conda-recipes/tornado_m2crypto/meta.yaml
@@ -12,18 +12,17 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
     - pip
-    - python
+    - python >=3.9
     - setuptools_scm
   run:
-    - enum34
     - m2crypto
-    - python
+    - python >=3.9
     - tornado ==5.1.1+dirac.*
 
 test:


### PR DESCRIPTION
Not much to say other than [it isn't needed](https://github.com/DIRACGrid/tornado_m2crypto/blob/258eea157db994bbd01c9474da63a98720195986/setup.py#L23).