### PR TITLE
fix array declaration for install_site

### DIFF
--- a/install_site.sh
+++ b/install_site.sh
@@ -23,7 +23,7 @@ install_root="${PWD}"
 extension="DIRAC"
 version=""
 install_cfg=""
-declare -a extra_pip_install
+extra_pip_install=()
 
 # Parse the arguments
 while [ "${1:-}" ]; do


### PR DESCRIPTION
When running bash with -u, an array declared with `declare -a` is considered as unbound variable if you do not put anything in it. It is not if you declare the array with `()`
Noticed while installing new EL9 machine.
I don't know why it was not spotted before



```bash
[dirac@lbvobox900 ~]$ set +u
[dirac@lbvobox900 ~]$ declare -a with_declare
[dirac@lbvobox900 ~]$ echo "${with_declare[@]}"

[dirac@lbvobox900 ~]$ echo "${#with_declare[@]}"
0
[dirac@lbvobox900 ~]$ with_parent=()
[dirac@lbvobox900 ~]$ echo "${with_parent[@]}"

[dirac@lbvobox900 ~]$ echo "${#with_parent[@]}"
0




[dirac@lbvobox900 ~]$ set -u
[dirac@lbvobox900 ~]$ declare -a with_declare
[dirac@lbvobox900 ~]$ echo "${with_declare[@]}"

[dirac@lbvobox900 ~]$ echo "${#with_declare[@]}"
-bash: with_declare: unbound variable
[dirac@lbvobox900 ~]$ with_parent=()
[dirac@lbvobox900 ~]$ echo "${with_parent[@]}"

[dirac@lbvobox900 ~]$ echo "${#with_parent[@]}"
0
```