### PR TITLE
feat: add assigned reviewer column to PR review reminder

### DIFF
--- a/.github/workflows/pr-review-reminder.yml
+++ b/.github/workflows/pr-review-reminder.yml
@@ -39,6 +39,12 @@ jobs:
                     }
                     reviewRequests(first: 10) {
                       totalCount
+                      nodes {
+                        requestedReviewer {
+                          ... on User { login }
+                          ... on Team { name }
+                        }
+                      }
                     }
                   }
                 }
@@ -77,13 +83,18 @@ jobs:
                   status = ":hourglass: Awaiting review";
                 }
 
-                return `| [#${pr.number}](${pr.url}) | ${pr.title} | ${author} | ${age}d | ${status} |`;
+                const reviewers = pr.reviewRequests.nodes
+                  .map(r => r.requestedReviewer?.login || r.requestedReviewer?.name || "")
+                  .filter(Boolean)
+                  .join(", ") || "-";
+
+                return `| [#${pr.number}](${pr.url}) | ${pr.title} | ${author} | ${reviewers} | ${age}d | ${status} |`;
               });
 
               sections.push(
                 `#### ${data.nameWithOwner}\n` +
-                "| PR | Title | Author | Age | Status |\n" +
-                "|:---|:------|:-------|:----|:-------|\n" +
+                "| PR | Title | Author | Reviewer | Age | Status |\n" +
+                "|:---|:------|:-------|:---------|:----|:-------|\n" +
                 rows.join("\n")
               );
             }


### PR DESCRIPTION
## Summary
- Add a "Reviewer" column to the Mattermost PR review summary table
- Expand the GraphQL query to fetch requested reviewer names (users and teams)
- Shows comma-separated reviewer names, or `-` if none assigned

Addresses feedback from #68.